### PR TITLE
Fix for error when running multiple spec files in succession, Port already in use

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -63,7 +63,6 @@ const assert = require('assert')
 const tunnel = require('tunnel-ssh')
 
 function bonnieFHIRDeleteMeasuresAndPatients (sshTunnel, config, userId) {
-
   const sshTunnelConfig = {
     agent: process.env.SSH_AUTH_SOCK,
     username: sshTunnel.username,
@@ -108,10 +107,12 @@ function bonnieFHIRDeleteMeasuresAndPatients (sshTunnel, config, userId) {
           console.log(err)
         }
         console.log(item)
+
         client.close()
+        server.close(client)
+        setImmediate(function(){server.emit('close')})
       })
     })
-
   })
 }
 


### PR DESCRIPTION
Fix for Port is already in use error. This happens when closing the connection takes longer than the next spec or test tries to open a connection on the same port. This change forces the closing of that connection.